### PR TITLE
Sinatra setup

### DIFF
--- a/app/services/mset_service.rb
+++ b/app/services/mset_service.rb
@@ -1,5 +1,11 @@
 class MsetService
 
+  def test_params(name)
+    conn.get('/test2') do |req|
+      req.params[:med_name] = 'adderall'
+    end
+  end
+
   def test(uri)
     conn.get(uri)
   end

--- a/app/services/mset_service.rb
+++ b/app/services/mset_service.rb
@@ -1,0 +1,14 @@
+class MsetService
+
+  def search_meds(uri)
+    response = conn.get(uri)
+    json = JSON.parse(response.body, symbolize_names: true)
+  end
+
+  private
+
+  def conn
+    Faraday.new(ENV['MSET_SERVICE'])
+  end
+  
+end

--- a/app/services/mset_service.rb
+++ b/app/services/mset_service.rb
@@ -16,6 +16,9 @@ class MsetService
     # run $ rackup from mset_service_app
     # directory for this connection to work.
     Faraday.new('http://localhost:9292')
+
+    # using mset_service_app on heroku:
+    # will only work once mset_service is updated on heroku with latest PR. Faraday.new(ENV['MSET_API_SERVICE_DOMAIN'])
   end
 
 end

--- a/app/services/mset_service.rb
+++ b/app/services/mset_service.rb
@@ -1,14 +1,15 @@
 class MsetService
 
-  def search_meds(uri)
-    response = conn.get(uri)
-    json = JSON.parse(response.body, symbolize_names: true)
+  def test(uri)
+    conn.get(uri)
   end
 
   private
 
   def conn
-    Faraday.new(ENV['MSET_SERVICE'])
+    # run $ rackup from mset_service_app
+    # directory for this connection to work.
+    Faraday.new('http://localhost:9292')
   end
-  
+
 end

--- a/spec/mset_requests/connection_spec.rb
+++ b/spec/mset_requests/connection_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe 'can connect to mset_service_app in sinatra' do
+
+  service = MsetService.new
+  service.search_meds('/v1/med_search')
+
+  expect(response).to have_http_status(:success)
+  expect(response.body).to have_content("Hello World")
+end

--- a/spec/mset_requests/connection_spec.rb
+++ b/spec/mset_requests/connection_spec.rb
@@ -1,8 +1,9 @@
-RSpec.describe 'can connect to mset_service_app in sinatra' do
+RSpec.describe 'sinatra connection' do
+  it 'can connect to mset_service_app in sinatra' do
+    service = MsetService.new
+    answer = service.test('/test')
 
-  service = MsetService.new
-  service.search_meds('/v1/med_search')
-
-  expect(response).to have_http_status(:success)
-  expect(response.body).to have_content("Hello World")
+    expect(answer.status).to eq(200)
+    expect(answer.body).to eq("Hello World")
+  end
 end

--- a/spec/mset_requests/connection_spec.rb
+++ b/spec/mset_requests/connection_spec.rb
@@ -1,9 +1,19 @@
 RSpec.describe 'sinatra connection' do
+  before :each do
+    @service = MsetService.new
+  end
+
   it 'can connect to mset_service_app in sinatra' do
-    service = MsetService.new
-    answer = service.test('/test')
+    answer = @service.test('/test')
 
     expect(answer.status).to eq(200)
     expect(answer.body).to eq("Hello World")
+  end
+
+  it 'can send a param' do
+    answer = @service.test_params('adderall')
+
+    expect(answer.status).to eq(200)
+    expect(answer.body).to eq('adderall')
   end
 end


### PR DESCRIPTION
#### Description

- this PR is for test/proof of concept for hooking up to sinatra via a Faraday call on `mset_app` in rails. 
- wrote a test for it: `spec/mset_requests`
- created `app/services/mset_service.rb` with the faraday connection to sinatra app.
- for purposes of testing, sinatra is just run locally for the connection to work. 
- more info and instructions in the `mset_api_service` [README](https://github.com/gabichuelas/mset_api_service).

