### PR TITLE
Test page content when birthdate and weight not included in usre profile

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -7,7 +7,7 @@
   <div class="sidebar">
     <div class="profile">
       <h5>Profile</h5>
-      <% if current_user.birthdate.empty? || current_user.birthdate.nil? %>
+      <% if current_user.birthdate.nil? || current_user.birthdate.empty? %>
         <p><strong>Date of birth:</strong> not saved</p>
       <% else %>
         <p><strong>Date of birth:</strong> <%= current_user.birthdate %></p>

--- a/spec/features/dashboard/dashboard_index_spec.rb
+++ b/spec/features/dashboard/dashboard_index_spec.rb
@@ -33,4 +33,14 @@ RSpec.describe 'As an authenticated user' do
     visit dashboard_path
     expect(page).to have_content("1985-09-01")
   end
+
+  it 'In the profile section, a note about birthdate and weight not being saved appears if I didn\'t include those in my profile' do
+    user = create(:user, birthdate: nil, weight: nil)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    visit dashboard_path
+    within('.profile') do
+      expect(page).to have_content("Date of birth: not saved")
+      expect(page).to have_content("Weight: not saved")
+    end
+  end
 end


### PR DESCRIPTION
#### Description
This user story was addressed by #30, but this PR adds a test to confirm page content within the profile section when a user has not added birthdate and weight to their profile.

There might be a merge conflict if #34 is merged before this one - if that happens, I'm happy to resolve the conflicts myself

#### Closes issue(s)
#16 