### PR TITLE
meds search fix when no adverse rxns table exists

### DIFF
--- a/app/facades/search_results_facade.rb
+++ b/app/facades/search_results_facade.rb
@@ -12,7 +12,7 @@ class SearchResultsFacade
 
   def extract_symptoms(product_ndc)
     tables = adverse_reactions_table(product_ndc)
-    return nil if tables[0].nil?
+    return nil if tables.nil? || tables[0].nil?
     symptoms = []
     tables.each do |table|
       table.each do |t|
@@ -29,6 +29,7 @@ class SearchResultsFacade
   def adverse_reactions_table(product_ndc)
     response = @service.sym_search(product_ndc)
     results = json_parse(response)[:results]
+    return nil if results.nil?
     results.map do |result|
       result[:adverse_reactions_table]
     end


### PR DESCRIPTION
#### Description
addresses scenario in which the code was erring out when a medication search result does not have an adverse rxns table

#### Closes issue(s)
closes #40 
