### PR TITLE
Med hash refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,6 @@ group :development, :test do
   gem 'simplecov'
   gem 'shoulda-matchers'
   gem 'factory_bot_rails'
-  gem 'webmock'
-  gem 'vcr'
   gem 'pry'
   gem 'travis'
   gem 'figaro'

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -2,8 +2,9 @@ class MedicationsController < ApplicationController
   def new; end
 
   def search
+    # binding.pry
     results = SEARCH_RESULTS.med_search_results(med_params[:brand_name])
-    return @med_hash = results unless results.nil?
+    return @med_results = results unless results.nil?
     flash[:warning] = "Sorry, your search did not return any results. Please try another search."
     redirect_to '/medications/new'
   end

--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -2,7 +2,6 @@ class MedicationsController < ApplicationController
   def new; end
 
   def search
-    # binding.pry
     results = SEARCH_RESULTS.med_search_results(med_params[:brand_name])
     return @med_results = results unless results.nil?
     flash[:warning] = "Sorry, your search did not return any results. Please try another search."

--- a/app/facades/search_results_facade.rb
+++ b/app/facades/search_results_facade.rb
@@ -7,7 +7,7 @@ class SearchResultsFacade
     response = @service.med_search(name)
     results = json_parse(response)[:results]
     return nil if results.nil?
-    med_and_ndc_hash(results)
+    create_medsearchresult_objects(results)
   end
 
   def save_symptoms(med_id)
@@ -55,7 +55,7 @@ class SearchResultsFacade
     end
   end
 
-  def med_and_ndc_hash(results)
+  def create_medsearchresult_objects(results)
     med_hash = Hash.new(0)
     results.each do |result|
       if med_hash.keys.include?(result[:brand_name])

--- a/app/facades/search_results_facade.rb
+++ b/app/facades/search_results_facade.rb
@@ -56,6 +56,7 @@ class SearchResultsFacade
   end
 
   def med_and_ndc_hash(results)
+    # binding.pry
     # should this return a temporary_medication PORO
     # instead of a hash...?
     med_hash = Hash.new(0)
@@ -66,7 +67,10 @@ class SearchResultsFacade
         med_hash[result[:brand_name]] = result[:product_ndc]
       end
     end
-    med_hash
+
+    med_hash.map do |brand_name, product_ndc|
+      MedSearchResult.new(brand_name, product_ndc)
+    end
   end
 
   def json_parse(response)

--- a/app/facades/search_results_facade.rb
+++ b/app/facades/search_results_facade.rb
@@ -56,9 +56,6 @@ class SearchResultsFacade
   end
 
   def med_and_ndc_hash(results)
-    # binding.pry
-    # should this return a temporary_medication PORO
-    # instead of a hash...?
     med_hash = Hash.new(0)
     results.each do |result|
       if med_hash.keys.include?(result[:brand_name])

--- a/app/poros/med_search_result.rb
+++ b/app/poros/med_search_result.rb
@@ -2,7 +2,7 @@ class MedSearchResult
   attr_reader :brand_name, :product_ndc
 
   def initialize(brand_name, product_ndc)
-    @brand_name = brand_name #med_data[:brand_name]
-    @product_ndc = product_ndc #med_data[:product_ndc]
+    @brand_name = brand_name
+    @product_ndc = product_ndc
   end
 end

--- a/app/poros/med_search_result.rb
+++ b/app/poros/med_search_result.rb
@@ -1,8 +1,8 @@
 class MedSearchResult
   attr_reader :brand_name, :product_ndc
 
-  def initialize(med_data)
-    @brand_name = med_data[:brand_name]
-    @product_ndc = med_data[:product_ndc]
+  def initialize(brand_name, product_ndc)
+    @brand_name = brand_name #med_data[:brand_name]
+    @product_ndc = product_ndc #med_data[:product_ndc]
   end
 end

--- a/app/poros/med_search_result.rb
+++ b/app/poros/med_search_result.rb
@@ -1,0 +1,8 @@
+class MedSearchResult
+  attr_reader :brand_name, :product_ndc
+
+  def initialize(med_data)
+    @brand_name = med_data[:brand_name]
+    @product_ndc = med_data[:product_ndc]
+  end
+end

--- a/app/views/medications/search.html.erb
+++ b/app/views/medications/search.html.erb
@@ -1,6 +1,6 @@
 <h4>Please select the correct medication brand name</h4>
 <section class='medications'>
-  <% @med_hash.each do |medication_name, product_ndc| %>
-    <p><%= button_to "#{medication_name}", '/medications/create', params: {brand_name: medication_name, product_ndc: product_ndc}, method: :post %>
+  <% @med_results.each do |med| %>
+    <p><%= button_to "#{med.brand_name}", '/medications/create', params: {brand_name: med.brand_name, product_ndc: med.product_ndc}, method: :post %>
   <% end %>
 </section>

--- a/spec/poros/med_search_result_spec.rb
+++ b/spec/poros/med_search_result_spec.rb
@@ -1,11 +1,9 @@
 RSpec.describe MedSearchResult do
   it 'has attributes' do
-    data = {
-      brand_name: "Adderall",
-      product_ndc: "123-1234"
-    }
+    brand_name = "Adderall"
+    product_ndc = "123-1234"
 
-    adderall = MedSearchResult.new(data)
+    adderall = MedSearchResult.new(brand_name, product_ndc)
 
     expect(adderall).to be_an_instance_of(MedSearchResult)
     expect(adderall.brand_name).to eq("Adderall")

--- a/spec/poros/med_search_result_spec.rb
+++ b/spec/poros/med_search_result_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe MedSearchResult do
+  it 'has attributes' do
+    data = {
+      brand_name: "Adderall",
+      product_ndc: "123-1234"
+    }
+
+    adderall = MedSearchResult.new(data)
+
+    expect(adderall).to be_an_instance_of(MedSearchResult)
+    expect(adderall.brand_name).to eq("Adderall")
+    expect(adderall.product_ndc).to eq("123-1234")
+  end
+end


### PR DESCRIPTION
#### Description
Creates `MedSearchResult` PORO so that we're not passing a hash into the search results view
The code for creating this PORO is _slightly_ brittle (ie, if we decide that we want to save a medication's generic name as well, there are a few lines of code that we'd need to change, rather than just updating the PORO's `initialize` method). This is because the data to initialize the PORO is available as an array not a hash.

Nonetheless, we are no longer passing a hash into the view

#### Closes issue(s)
#44 