### PR TITLE
Fix #potential_symptoms

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,6 +2,6 @@ class DashboardController < ApplicationController
   before_action :require_user
 
   def index
-    @potential_symptoms = current_user.potential_symptoms
+    @potential_symptoms = Symptom.potential_symptoms(current_user)
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,13 +1,15 @@
 class LogsController < ApplicationController
   def create
-    symptom = Symptom.find_by(description: log_params[:symptom])
-    log = Log.create(user: current_user, symptom: symptom, note: log_params[:note], when: log_params[:when])
-    if log.save
-      flash[:success] = 'New symptom logged!'
-      redirect_to dashboard_path
-    elsif no_symptom? || no_when?
+    if no_symptom? || no_when?
       flash[:error] = 'Please be sure to specify a symptom and when you experienced it'
       redirect_to request.referer
+    else
+      symptom = Symptom.find(log_params[:symptom])
+      log = Log.create(user: current_user, symptom: symptom, note: log_params[:note], when: log_params[:when])
+      if log.save
+        flash[:success] = 'New symptom logged!'
+        redirect_to dashboard_path
+      end
     end
   end
 

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -4,4 +4,8 @@ class Symptom < ApplicationRecord
   has_many :medication_symptoms
   has_many :medications, through: :medication_symptoms
   has_many :logs
+
+  def self.potential_symptoms(user)
+    joins(medications: [:medication_symptoms, :user_medications]).where("user_medications.user_id=#{user.id}").distinct
+  end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -41,7 +41,7 @@
       <h3>Log a Symptom:</h3><br>
       <%= form_tag log_path, method: "post" do %>
         <%= label_tag "What symptom did you experience?"%><br>
-        <%= select_tag :symptom, options_for_select(@potential_symptoms), :include_blank => true %><br>
+        <%= select_tag :symptom, options_for_select(@potential_symptoms.collect{ |symptom| [symptom.description, symptom.id] }), :include_blank => true %><br>
 
         <%= label_tag "When?"%><br>
         <%= datetime_field_tag :when %><br>

--- a/spec/features/dashboard/medications_spec.rb
+++ b/spec/features/dashboard/medications_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'User can add a medication by name', type: :feature do
     end
   end
 
-  xit "Edge case: When I add a new medication without an adverse_reactions_table, user is redirected to dashboard and no symptoms are added" do
+  it "Edge case: When I add a new medication without an adverse_reactions_table, user is redirected to dashboard and no symptoms are added" do
     VCR.use_cassette('hand_sanitizer_search') do
 
       fill_in :brand_name, with: 'hand sanitizer'

--- a/spec/features/dashboard/new_symptom_log_spec.rb
+++ b/spec/features/dashboard/new_symptom_log_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
   before :each do
-    user = create(:user)
+    @user = create(:user)
     medication = create(:medication)
     symptom_1 = Symptom.create!(description: "Headache")
     symptom_2 = Symptom.create!(description: "Insomnia")
     MedicationSymptom.create!(medication: medication, symptom: symptom_1)
     MedicationSymptom.create!(medication: medication, symptom: symptom_2)
-    UserMedication.create!(user: user, medication: medication)
+    UserMedication.create!(user: @user, medication: medication)
 
-    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
 
     visit dashboard_path
   end
@@ -22,15 +22,17 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
       fill_in :note, with: "7/10 pain scale"
       click_button "Save"
     end
+    user = User.find(@user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("New symptom logged!")
 
-    # within('.recent-logs') do
-    #   expect(page).to have_content("Headache")
-    #   expect(page).to have_content("2020-09-13T23:09")
-    #   expect(page).to have_content(7/10 pain scale")
-    # end
+    within('.recent-logs') do
+      expect(page).to have_content("Headache")
+      expect(page).to have_content("2020-09-13 23:09:00 UTC")
+      expect(page).to have_content("7/10 pain scale")
+    end
     # the spec seems to not register that current_user now has a new log relationship
     # works in server but not in the test
   end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -5,10 +5,38 @@ RSpec.describe Log do
   it { should belong_to :user }
   it { should belong_to :symptom }
 
-  it "methods" do
-    user = create(:user)
-    symptom = Symptom.create!(description: "Headache")
-    log = Log.create!(user: user, symptom: symptom, when: DateTime.now)
-    expect(log.symptom_description).to eq("Headache")
+  describe 'methods' do
+    it '#symptom_description' do
+      user = create(:user)
+      symptom = Symptom.create!(description: "Headache")
+      log = Log.create!(user: user, symptom: symptom, when: DateTime.now)
+      expect(log.symptom_description).to eq("Headache")
+    end
+
+    it '::potential_symptoms' do
+      user_1 = create(:user)
+      medication_1 = create(:medication)
+      symptom_1 = Symptom.create!(description: "Headache")
+      symptom_2 = Symptom.create!(description: "Insomnia")
+      MedicationSymptom.create!(medication: medication_1, symptom: symptom_1)
+      MedicationSymptom.create!(medication: medication_1, symptom: symptom_2)
+      UserMedication.create!(user: user_1, medication: medication_1)
+
+      user_2 = create(:user)
+      medication_2 = create(:medication, brand_name: "Xanax")
+      symptom_3 = Symptom.create!(description: "Stomach pain")
+      MedicationSymptom.create!(medication: medication_2, symptom: symptom_3)
+      UserMedication.create!(user: user_2, medication: medication_2)
+
+      expect(Symptom.potential_symptoms(user_1)).to_not eq(Symptom.potential_symptoms(user_2))
+
+      expect(Symptom.potential_symptoms(user_1)).to include(symptom_1)
+      expect(Symptom.potential_symptoms(user_1)).to include(symptom_2)
+      expect(Symptom.potential_symptoms(user_1)).to_not include(symptom_3)
+
+      expect(Symptom.potential_symptoms(user_2)).to include(symptom_3)
+      expect(Symptom.potential_symptoms(user_2)).to_not include(symptom_1)
+      expect(Symptom.potential_symptoms(user_2)).to_not include(symptom_2)
+    end
   end
 end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -58,5 +58,3 @@ RSpec.describe Log do
     end
   end
 end
-
-# end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Log do
       log_3 = Log.create(user: user, symptom: symptom_3, when: log_3_time)
 
       ordered_logs = [log_3, log_1, log_2]
+
+      expect(Log.order_by_when).to eq(ordered_logs)
     end
 
     it '::potential_symptoms' do
@@ -53,7 +55,8 @@ RSpec.describe Log do
       expect(Symptom.potential_symptoms(user_2)).to include(symptom_3)
       expect(Symptom.potential_symptoms(user_2)).to_not include(symptom_1)
       expect(Symptom.potential_symptoms(user_2)).to_not include(symptom_2)
-      expect(Log.order_by_when).to eq(ordered_logs)
     end
   end
 end
+
+# end


### PR DESCRIPTION
#### Description
`#potential_symptoms` used to be a `User` model instance method that returned the names of potential symptoms based on _all_ medications in the db
It is now a `Symptom` model class method that returns only the current user's potential symptoms

model spec is ready

#### Closes issue(s)
closes #64 
