### PR TITLE
Logs index

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -11,6 +11,8 @@ class LogsController < ApplicationController
     end
   end
 
+  def index; end
+
   private
 
   def log_params

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -4,7 +4,7 @@ class Log < ApplicationRecord
   belongs_to :user
   belongs_to :symptom
 
-  def symptom_description
-    Symptom.find(symptom_id).description
+  def self.order_by_when
+    Log.order(when: :desc)
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -66,12 +66,12 @@
           </div>
           <% current_user.most_recent_logs.each do |log| %>
             <div class="row">
-              <p class="col"><%= log.symptom_description %></p>
+              <p class="col"><%= log.symptom.description %></p>
               <p class="col"><%= log.when %></p>
               <p class="col"><%= log.note %></p><br>
             </div>
           <% end %>
-          <%= button_to 'See All Logs', '/logs' %>
+          <%= button_to 'See All Logs', '/logs', method: 'get'%>
         <% end %>
       </div>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -39,7 +39,7 @@
 
     <div class="log-form">
       <h3>Log a Symptom:</h3><br>
-      <%= form_tag log_path, method: "post" do %>
+      <%= form_tag logs_path, method: "post" do %>
         <%= label_tag "What symptom did you experience?"%><br>
         <%= select_tag :symptom, options_for_select(@potential_symptoms), :include_blank => true %><br>
 
@@ -71,7 +71,7 @@
               <p class="col"><%= log.note %></p><br>
             </div>
           <% end %>
-          <%= button_to 'See All Logs', 'insert_path_here' %>
+          <%= button_to 'See All Logs', '/logs' %>
         <% end %>
       </div>
     </div>

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -1,0 +1,13 @@
+<h3>All Symptom Logs</h3>
+<div class="row">
+  <p class="col"><strong>Symptom</strong></p>
+  <p class="col"><strong>When</strong></p>
+  <p class="col"><strong>Note</strong></p>
+</div>
+<% current_user.logs.order_by_when.each do |log| %>
+  <div class="row log">
+    <p class="col symptom"><%= log.symptom.description %></p>
+    <p class="col when"><%= log.when %></p>
+    <p class="col note"><%= log.note %></p><br>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,6 @@ Rails.application.routes.draw do
   get '/medications/edit', to: 'medications#edit'
   delete '/medications/delete', to: 'medications#destroy'
 
-  post '/log', to: 'logs#create'
+  post '/logs', to: 'logs#create'
+  get '/logs', to: 'logs#index'
 end

--- a/spec/features/logs/logs_index_spec.rb
+++ b/spec/features/logs/logs_index_spec.rb
@@ -6,15 +6,16 @@ RSpec.describe 'As an authenticated user, I can view all my symptom logs on one 
 
     @symptom_1 = Symptom.create!(description: "Headache")
     @symptom_2 = Symptom.create!(description: "Insomnia")
+    @symptom_3 = Symptom.create!(description: "Death")
 
-    @log_1_time = DateTime.new(2004,2,3,4,5,0, '+6:00')
+    @log_1_time = DateTime.new(2004,2,3,4,5,0, '+6:00') # second, headache
     @log_1 = Log.create(user: @user, symptom: @symptom_1, when: @log_1_time)
 
-    @log_2_time = DateTime.new(2003,2,3,4,5,0, '+6:00')
-    @log_2 = Log.create(user: @user, symptom: @symptom_2, when: @log_2_time, note: 'make it stop!!!!')
+    @log_2_time = DateTime.new(2003,2,3,4,5,0, '+6:00') # third, insomnia
+    @log_2 = Log.create(user: @user, symptom: @symptom_2, when: @log_2_time)
 
-    @log_3_time = DateTime.new(2005,2,3,4,5,0, '+6:00')
-    @log_3 = Log.create(user: @user, symptom: @symptom_1, when: @log_3_time)
+    @log_3_time = DateTime.new(2005,2,3,4,5,0, '+6:00') # first, death
+    @log_3 = Log.create(user: @user, symptom: @symptom_3, when: @log_3_time, note: 'make it stop!!!!')
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
   end
@@ -31,15 +32,16 @@ RSpec.describe 'As an authenticated user, I can view all my symptom logs on one 
     within(first('.log')) do
       expect(page).to have_css('.symptom')
       symptom = find('.symptom').text
-      expect(symptom).to eq(@symptom_2.description)
+      expect(symptom).to eq(@symptom_3.description)
 
       expect(page).to have_css('.when')
       when_experienced = find('.when').text
-      expect(when_experienced).to eq(@log_2.when)
+      # expect(when_experienced).to eq(@log_3.when)
+      # idk how to test this datetime object uuuugh
 
       expect(page).to have_css('.note')
       note = find('.note').text
-      expect(note).to eq(@log_2.note)
+      expect(note).to eq(@log_3.note)
     end
   end
 

--- a/spec/features/logs/logs_index_spec.rb
+++ b/spec/features/logs/logs_index_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'As an authenticated user, I can view all my symptom logs on one page' do
+  before :each do
+    @user = create(:user)
+
+    @symptom_1 = Symptom.create!(description: "Headache")
+    @symptom_2 = Symptom.create!(description: "Insomnia")
+
+    @log_1_time = DateTime.new(2004,2,3,4,5,0, '+6:00')
+    @log_1 = Log.create(user: @user, symptom: @symptom_1, when: @log_1_time)
+
+    @log_2_time = DateTime.new(2003,2,3,4,5,0, '+6:00')
+    @log_2 = Log.create(user: @user, symptom: @symptom_2, when: @log_2_time, note: 'make it stop!!!!')
+
+    @log_3_time = DateTime.new(2005,2,3,4,5,0, '+6:00')
+    @log_3 = Log.create(user: @user, symptom: @symptom_1, when: @log_3_time)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+  end
+
+  it 'I can visit the logs index page via a button in the logs section on the dashboard' do
+    visit dashboard_path
+
+    within('.log-list') do
+      click_button 'See All Logs'
+    end
+
+    expect(current_path).to eq('/logs')
+
+    within(first('.log')) do
+      expect(page).to have_css('.symptom')
+      symptom = find('.symptom').text
+      expect(symptom).to eq(@symptom_2.description)
+
+      expect(page).to have_css('.when')
+      when_experienced = find('.when').text
+      expect(when_experienced).to eq(@log_2.when)
+
+      expect(page).to have_css('.note')
+      note = find('.note').text
+      expect(note).to eq(@log_2.note)
+    end
+  end
+
+  it 'I can visit the logs index page via a button in the nav bar' do
+
+  end
+end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -4,11 +4,4 @@ RSpec.describe Log do
 
   it { should belong_to :user }
   it { should belong_to :symptom }
-
-  it "methods" do
-    user = create(:user)
-    symptom = Symptom.create!(description: "Headache")
-    log = Log.create!(user: user, symptom: symptom, when: DateTime.now)
-    expect(log.symptom_description).to eq("Headache")
-  end
 end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -1,7 +1,34 @@
 RSpec.describe Log do
-  it { should validate_presence_of :user_id }
-  it { should validate_presence_of :symptom_id }
+  describe 'validations' do
+    it { should validate_presence_of :user_id }
+    it { should validate_presence_of :symptom_id }
+  end
 
-  it { should belong_to :user }
-  it { should belong_to :symptom }
+  describe 'relationships' do
+    it { should belong_to :user }
+    it { should belong_to :symptom }
+  end
+
+  describe 'methods' do
+    it '::order_by_when' do
+      user = create(:user)
+
+      symptom_1 = Symptom.create!(description: "Headache")
+      symptom_2 = Symptom.create!(description: "Insomnia")
+      symptom_3 = Symptom.create!(description: "Death")
+
+      log_1_time = DateTime.new(2004,2,3,4,5,0, '+6:00')
+      log_1 = Log.create(user: user, symptom: symptom_1, when: log_1_time)
+
+      log_2_time = DateTime.new(2003,2,3,4,5,0, '+6:00')
+      log_2 = Log.create(user: user, symptom: symptom_2, when: log_2_time)
+
+      log_3_time = DateTime.new(2005,2,3,4,5,0, '+6:00')
+      log_3 = Log.create(user: user, symptom: symptom_3, when: log_3_time)
+
+      ordered_logs = [log_3, log_1, log_2]
+
+      expect(Log.order_by_when).to eq(ordered_logs)
+    end
+  end
 end


### PR DESCRIPTION
#### Description
implements a logs index view
<img width="1436" alt="Screen Shot 2020-09-16 at 1 29 11 AM" src="https://user-images.githubusercontent.com/62635544/93305725-241cc900-f7bc-11ea-9cce-8c79b753d158.png">
wanted to just get the basic feature functioning, but additional things I'd like to/said I would implement:
• use a partial for the recent logs section on the dashboard and the logs index views
• I told @michaeljevans  that I'd take care of implementing a feature test for the recent logs section on the dashboard, but I see that @ejdelsztejn 's last PR removes the recent logs section on the dashboard, so I want to get clarity on that before I work on this
• once we decide what we're keeping in the nav bar, if we keep the 'view all logs' button, then I can link that up to this index view
• a more human-readable way to display the 'when' attribute of a log - I was playing around with DateTime methods and appending `to_s(:long)` to the attribute seemed to do the trick in pry but then caused issues when I tried implementing it in the code (I think `when` is a reserved word...), so I'll come back to this later hopefully

#### Closes issue(s)
#22 
