### PR TITLE
Log symptom update

### DIFF
--- a/"form-control"}
+++ b/"form-control"}
@@ -1,0 +1,2 @@
+[log_symptom_update 9d86f26] Update no_when? method to check params[:when] == {:class=
+ 3 files changed, 4 insertions(+), 5 deletions(-)

--- a/"form-control"}
+++ b/"form-control"}
@@ -1,2 +1,0 @@
-[log_symptom_update 9d86f26] Update no_when? method to check params[:when] == {:class=
- 3 files changed, 4 insertions(+), 5 deletions(-)

--- a/app/assets/stylesheets/dashboard/index.scss
+++ b/app/assets/stylesheets/dashboard/index.scss
@@ -72,32 +72,3 @@
 .log-list p {
   margin-bottom: 10px;
 }
-
-
-// .input {
-//   box-sizing: border-box;
-//   font-size: 2rem;
-//   padding: 1rem;
-//   display: block;
-//   margin: 2rem auto;
-// }
-
-// .ul {
-//   list-style: none;
-//   text-align: center;
-//   margin: 0;
-//   padding: 0;
-// }
-
-// .li {
-//   color: #666;
-//   strong { color: #000; }
-//   + .label { margin-top: 1rem; }
-//   &.label {
-//     color: #CCC;
-//     text-transform: uppercase;
-//     font-size: 0.8em;
-//     letter-spacing: 0.0125em;
-//     margin-bottom: 0.25rem;
-//   }
-// }

--- a/app/assets/stylesheets/dashboard/index.scss
+++ b/app/assets/stylesheets/dashboard/index.scss
@@ -26,8 +26,10 @@
   border-radius: 8px;
   background-color: white;
   padding: 30px;
-  flex-basis: 343px;
+  // flex-basis: 343px;
   margin-bottom: 20px;
+  margin-right: 10px;
+  flex-grow: 1;
 }
 
 .med-list a {
@@ -36,7 +38,7 @@
 }
 
 .profile {
-  margin-bottom: 50px;
+  margin-bottom: 40px;
 }
 
 .details {
@@ -49,6 +51,8 @@
   background-color: white;
   padding: 30px;
   margin-bottom: 20px;
+  margin-left: 10px;
+  flex-grow: 3;
 }
 
 .log-form {
@@ -61,7 +65,7 @@
 }
 
 .log-list {
-  margin: 25px 0px 15px 0px;
+  margin: 25px 0px 10px 0px;
   text-align: left;
 }
 
@@ -69,30 +73,31 @@
   margin-bottom: 10px;
 }
 
-.input {
-  box-sizing: border-box;
-  font-size: 2rem;
-  padding: 1rem;
-  display: block;
-  margin: 2rem auto;
-}
 
-.ul {
-  list-style: none;
-  text-align: center;
-  margin: 0;
-  padding: 0;
-}
+// .input {
+//   box-sizing: border-box;
+//   font-size: 2rem;
+//   padding: 1rem;
+//   display: block;
+//   margin: 2rem auto;
+// }
 
-.li {
-  color: #666;
-  strong { color: #000; }
-  + .label { margin-top: 1rem; }
-  &.label {
-    color: #CCC;
-    text-transform: uppercase;
-    font-size: 0.8em;
-    letter-spacing: 0.0125em;
-    margin-bottom: 0.25rem;
-  }
-}
+// .ul {
+//   list-style: none;
+//   text-align: center;
+//   margin: 0;
+//   padding: 0;
+// }
+
+// .li {
+//   color: #666;
+//   strong { color: #000; }
+//   + .label { margin-top: 1rem; }
+//   &.label {
+//     color: #CCC;
+//     text-transform: uppercase;
+//     font-size: 0.8em;
+//     letter-spacing: 0.0125em;
+//     margin-bottom: 0.25rem;
+//   }
+// }

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -26,6 +26,6 @@ class LogsController < ApplicationController
   end
 
   def no_when?
-    params[:when].nil? || params[:when].empty?
+    params[:when].nil? || params[:when] == "{:class=>\"form-control\"}"
   end
 end

--- a/app/controllers/symptoms_controller.rb
+++ b/app/controllers/symptoms_controller.rb
@@ -2,8 +2,8 @@ require 'fuzzystringmatch'
 
 class SymptomsController < ApplicationController
   def search
-    if search_params[:symptom].empty? || search_params[:symptom] == ' ' || search_params[:when].empty?
-      flash[:error] = 'Please be sure to specify a symptom and when you experienced it'
+    if search_params[:symptom].empty? || search_params[:symptom] == ' '
+      flash[:error] = 'Please be sure to specify a symptom'
       redirect_to request.referer
     else
       jarow = FuzzyStringMatch::JaroWinkler.create(:native)
@@ -13,14 +13,12 @@ class SymptomsController < ApplicationController
       end
 
       @results << search_params[:symptom] if @results.empty?
-
-      @log_hash = {when: search_params[:when], note: search_params[:note]}
     end
   end
 
   private
 
   def search_params
-    params.permit(:symptom, :when, :note)
+    params.permit(:symptom)
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -47,28 +47,16 @@
           <div class="col-sm">
             <%= label_tag "What symptom did you experience?"%><br>
           </div>
-          <div class="col-sm">
-            <%= label_tag "When?"%><br>
-          </div>
-          <div class="col-sm">
-            <%= label_tag "Any additional notes?"%><br>
-          </div>
         </div>
-
         <div class="form-row">
           <div class="col-sm">
             <%= text_field_tag :symptom, nil, placeholder: 'Search Symptoms' %>
           </div>
-          <div class="col-sm">
-           	<%= datetime_field_tag :when %>
-          </div>
-          <div class="col-sm">
-            <%= text_area_tag :note %>
-          </div>
         </div>
+        <br>
         <div class="row">
           <div class="col-sm">
-            <%= submit_tag 'Save', class: "btn btn-primary" %>
+            <%= submit_tag 'Search for Symptom', class: "btn btn-primary" %>
           </div>
         </div>
         <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -34,7 +34,7 @@
                <li><%= medication.brand_name %></li>
              <% end %>
            </ul>
-           <%= link_to "Edit Medication List", "/medications/edit", method: :get %>
+           <%= link_to "Edit Medication List", "/medications/edit", method: :get %><br>
            <a href="/medications/new" class="btn btn-primary">Add New Medication</a>
         <% end %>
       </div>
@@ -72,10 +72,8 @@
       <h4>Recent Symptom Logs</h4>
       <div class="log-list">
         <%= render partial: '/partials/logs_list', locals: {logs: current_user.most_recent_logs} %>
-        <div class="row">
-          <a href="/logs" class="btn btn-primary">See All Logs</a>
-        </div>
       </div>
+      <a href="/logs" class="btn btn-primary">See All Logs</a>
     </div>
   </div>
 </div>

--- a/app/views/symptoms/search.html.erb
+++ b/app/views/symptoms/search.html.erb
@@ -1,4 +1,38 @@
-<h2>Select the correct symptom</h2>
-<% @results.each do |result| %>
-  <p><%= button_to "#{result}", '/logs', params: {symptom: result, when: @log_hash[:when], note: @log_hash[:note]}, method: :post %></p>
-<% end %>
+<div class="log-form">
+  <h4>Select the correct symptom and when you experienced it</h4><br>
+
+  <div class="form">
+    <%= form_tag logs_path, method: :post do %>
+    <div class="form-row">
+      <div class="col-sm">
+        <%= label_tag "Which symptom did you experience?"%><br>
+      </div>
+      <div class="col-sm">
+        <%= label_tag "When?"%><br>
+      </div>
+      <div class="col-sm">
+        <%= label_tag "Any additional notes?"%><br>
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="col-sm">
+        <% @results.each do |result| %>
+          <%= radio_button_tag :symptom, "#{result}" %> <%= result %><br/>
+        <% end %>
+      </div>
+      <div class="col-sm">
+     	<%= datetime_field_tag :when %>
+      </div>
+      <div class="col-sm">
+        <%= text_area_tag :note %>
+      </div>
+    </div>
+    <br>
+    <div class="row">
+      <div class="col-sm">
+        <%= submit_tag 'Save', class: "btn btn-primary" %>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/symptoms/search.html.erb
+++ b/app/views/symptoms/search.html.erb
@@ -1,6 +1,6 @@
 <div class="log-form">
+  <%= render partial: '/partials/flash' %>
   <h4>Select the correct symptom and when you experienced it</h4><br>
-
   <div class="form">
     <%= form_tag logs_path, method: :post do %>
     <div class="form-row">

--- a/spec/features/dashboard/dashboard_index_spec.rb
+++ b/spec/features/dashboard/dashboard_index_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe 'As an authenticated user' do
       visit dashboard_path
       within('.log-form') do
         expect(page).to have_css('#symptom')
-        # expect(page).to have_css('#when')
-        # expect(page).to have_css('#note')
         expect(page).to have_button('Search for Symptom')
       end
     end

--- a/spec/features/dashboard/dashboard_index_spec.rb
+++ b/spec/features/dashboard/dashboard_index_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe 'As an authenticated user' do
       visit dashboard_path
       within('.log-form') do
         expect(page).to have_css('#symptom')
-        expect(page).to have_css('#when')
-        expect(page).to have_css('#note')
-        expect(page).to have_button('Save')
+        # expect(page).to have_css('#when')
+        # expect(page).to have_css('#note')
+        expect(page).to have_button('Search for Symptom')
       end
     end
   end

--- a/spec/features/dashboard/new_symptom_log_spec.rb
+++ b/spec/features/dashboard/new_symptom_log_spec.rb
@@ -77,54 +77,65 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
 
   it 'If I try to log a new symptom without selecting a symptom, I receive an error' do
     within('.log-form') do
-      fill_in :when, with: "2020-09-13T23:09"
-      fill_in :note, with: "7/10 pain scale"
       click_button "Search for Symptom"
     end
 
     expect(current_path).to eq(dashboard_path)
-    expect(page).to have_content('Please be sure to specify a symptom and when you experienced it')
+    expect(page).to have_content('Please be sure to specify a symptom')
   end
 
   it 'If I try to log a new symptom without selecting a date/time, I receive an error' do
     within('.log-form') do
       fill_in :symptom, with: "Headache"
-      fill_in :note, with: "7/10 pain scale"
       click_button "Search for Symptom"
     end
+    user = User.find(@user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    expect(current_path).to eq(dashboard_path)
+    expect(current_path).to eq('/symptoms/search')
+    expect(page).to have_content('Select the correct symptom and when you experienced it')
+    choose(option: 'Headache')
+    expect(page).to have_button('Save')
+    click_on 'Save'
+
+    expect(current_path).to eq(symptoms_search_path)
     expect(page).to have_content('Please be sure to specify a symptom and when you experienced it')
   end
 
   it 'If I try to log a new symptom without selecting a symptom and date/time, I receive an error' do
     within('.log-form') do
-      fill_in :note, with: "7/10 pain scale"
+      fill_in :symptom, with: "Headache"
       click_button "Search for Symptom"
     end
 
-    expect(current_path).to eq(dashboard_path)
+    expect(current_path).to eq('/symptoms/search')
+    expect(page).to have_content('Select the correct symptom and when you experienced it')
+    expect(page).to have_button('Save')
+    click_on 'Save'
+
+    expect(current_path).to eq(symptoms_search_path)
     expect(page).to have_content('Please be sure to specify a symptom and when you experienced it')
   end
 
   it 'I can submit a log for an unlisted symptom' do
     within('.log-form') do
       fill_in :symptom, with: "Migraine"
-      fill_in :when, with: "2020-09-13T23:09"
-      fill_in :note, with: "Migraine - pain scale"
       click_button "Search for Symptom"
     end
 
     expect(current_path).to eq('/symptoms/search')
-    expect(page).to have_content('Select the correct symptom')
-    expect(page).to have_button('Migraine')
-    click_on 'Migraine'
+    expect(page).to have_content('Select the correct symptom and when you experienced it')
+    choose(option: 'Migraine')
+    fill_in :when, with: "2020-09-13T23:09"
+    expect(page).to have_button('Save')
+    click_on 'Save'
 
     expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("New symptom logged!")
 
-    # within('.recent-logs') do
-    expect(page).to have_content("Migraine")
-    # end
+    within('.recent-logs') do
+      expect(page).to have_content("Migraine")
+      expect(page).to have_content("2020-09-13 23:09:00 UTC")
+    end
   end
 end

--- a/spec/features/dashboard/new_symptom_log_spec.rb
+++ b/spec/features/dashboard/new_symptom_log_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
     within('.recent-logs') do
       expect(page).to have_content("Headache")
       expect(page).to have_content("2020-09-13 23:09:00 UTC")
-      expect(page).to have_content("7/10 pain scale")
     end
   end
 
@@ -75,7 +74,7 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
     expect(page).to have_content('Please be sure to specify a symptom')
   end
 
-  xit 'If I try to log a new symptom without selecting a date/time, I receive an error' do
+  it 'If I try to log a new symptom without selecting a date/time, I receive an error' do
     within('.log-form') do
       fill_in :symptom, with: "Headache"
       click_button "Search for Symptom"
@@ -98,6 +97,8 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
       fill_in :symptom, with: "Headache"
       click_button "Search for Symptom"
     end
+    user = User.find(@user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     expect(current_path).to eq('/symptoms/search')
     expect(page).to have_content('Select the correct symptom and when you experienced it')

--- a/spec/features/dashboard/new_symptom_log_spec.rb
+++ b/spec/features/dashboard/new_symptom_log_spec.rb
@@ -18,17 +18,18 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
   it 'I can log a new symptom, and see a flash message confirming the new log as well as the log displayed in the recent logs section' do
     within('.log-form') do
       fill_in :symptom, with: "Headache"
-      fill_in :when, with: "2020-09-13T23:09"
-      fill_in :note, with: "7/10 pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
     user = User.find(@user.id)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     expect(current_path).to eq('/symptoms/search')
-    expect(page).to have_content('Select the correct symptom')
-    expect(page).to have_button('Headache')
-    click_on 'Headache'
+    expect(page).to have_content('Select the correct symptom and when you experienced it')
+    choose(option: 'Headache')
+    fill_in :when, with: "2020-09-13T23:09"
+    fill_in :note, with: "7/10 pain scale"
+    expect(page).to have_button('Save')
+    click_on 'Save'
 
     expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("New symptom logged!")
@@ -45,18 +46,25 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
   it 'I can successfully log a new symptom without including a note' do
     within('.log-form') do
       fill_in :symptom, with: "Headache"
-      fill_in :when, with: "2020-09-13T23:09"
-      fill_in :note, with: "7/10 pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
+    user = User.find(@user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     expect(current_path).to eq('/symptoms/search')
-    expect(page).to have_content('Select the correct symptom')
-    expect(page).to have_button('Headache')
-    click_on 'Headache'
+    expect(page).to have_content('Select the correct symptom and when you experienced it')
+    choose(option: 'Headache')
+    fill_in :when, with: "2020-09-13T23:09"
+    expect(page).to have_button('Save')
+    click_on 'Save'
 
     expect(current_path).to eq(dashboard_path)
     expect(page).to have_content("New symptom logged!")
+
+    within('.recent-logs') do
+      expect(page).to have_content("Headache")
+      expect(page).to have_content("2020-09-13 23:09:00 UTC")
+    end
 
     # within('.recent-logs') do
     #   expect(page).to have_content("Headache")
@@ -71,7 +79,7 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
     within('.log-form') do
       fill_in :when, with: "2020-09-13T23:09"
       fill_in :note, with: "7/10 pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
 
     expect(current_path).to eq(dashboard_path)
@@ -82,7 +90,7 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
     within('.log-form') do
       fill_in :symptom, with: "Headache"
       fill_in :note, with: "7/10 pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
 
     expect(current_path).to eq(dashboard_path)
@@ -92,7 +100,7 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
   it 'If I try to log a new symptom without selecting a symptom and date/time, I receive an error' do
     within('.log-form') do
       fill_in :note, with: "7/10 pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
 
     expect(current_path).to eq(dashboard_path)
@@ -104,7 +112,7 @@ RSpec.describe 'As an authenticated user, when I visit my dashboard,' do
       fill_in :symptom, with: "Migraine"
       fill_in :when, with: "2020-09-13T23:09"
       fill_in :note, with: "Migraine - pain scale"
-      click_button "Save"
+      click_button "Search for Symptom"
     end
 
     expect(current_path).to eq('/symptoms/search')

--- a/spec/features/logs/logs_index_spec.rb
+++ b/spec/features/logs/logs_index_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'As an authenticated user, I can view all my symptom logs on one 
   it 'I can visit the logs index page via a button in the logs section on the dashboard' do
     visit dashboard_path
 
-    within('.log-list') do
+    within('.recent-logs') do
       click_on 'See All Logs'
     end
 


### PR DESCRIPTION
#### Description
This PR creates a more intuitive user experience for logging a symptom:
1. A user can enter a symptom into the search bar on the dashboard and click "Search for Symptom."
<img width="359" alt="Screen Shot 2020-09-16 at 9 14 18 PM" src="https://user-images.githubusercontent.com/43380627/93408109-c04cdb80-f861-11ea-884f-d505e47da08c.png">

2. The user can select the correct symptom from the possible choices, add when they experienced the symptom, and any additional notes.
<img width="1055" alt="Screen Shot 2020-09-16 at 9 14 31 PM" src="https://user-images.githubusercontent.com/43380627/93408116-c478f900-f861-11ea-98eb-1b1e3597ade0.png">

3. The symptom is logged! Yay!
<img width="679" alt="Screen Shot 2020-09-16 at 9 14 46 PM" src="https://user-images.githubusercontent.com/43380627/93408121-c5aa2600-f861-11ea-8ae6-ed9dd5013876.png">


#### Closes issue(s)
Closes issue #77 
