### PR TITLE
Med show page

### DIFF
--- a/app/controllers/medications_controller.rb
+++ b/app/controllers/medications_controller.rb
@@ -21,6 +21,10 @@ class MedicationsController < ApplicationController
     end
   end
 
+  def show
+    @medication = Medication.find(med_params[:id])
+  end
+
   def edit
     @medications = current_user.medications.all
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -31,7 +31,7 @@
         <% else %>
           <ul>
              <% current_user.medications.each do |medication| %>
-               <li><%= medication.brand_name %></li>
+               <li><%= link_to "#{medication.brand_name}", "/medications/#{medication.id}", method: :get %></li>
              <% end %>
            </ul>
            <%= link_to "Edit Medication List", "/medications/edit", method: :get %><br>

--- a/app/views/medications/show.html.erb
+++ b/app/views/medications/show.html.erb
@@ -2,7 +2,7 @@
 <%= button_to 'Delete Medication from my List', '/medications/delete', params: {id: @medication.id, brand_name: @medication.brand_name, product_ndc: @medication.product_ndc}, method: :delete %>
 <p>Brand Name: <%= @medication.brand_name %></p>
 <p>Product NDC: <%= @medication.product_ndc %></p>
-<% if @medication.symptoms.empty? == false %>
+<% unless @medication.symptoms.empty? %>
   <div class="side-effects"</div>
   <h4>Potential Side Effects:</h4>
   <% @medication.symptoms.each do |symptom| %>

--- a/app/views/medications/show.html.erb
+++ b/app/views/medications/show.html.erb
@@ -1,4 +1,5 @@
 <h3>Medication information</h3>
+<%= button_to 'Delete Medication from my List', '/medications/delete', params: {id: @medication.id, brand_name: @medication.brand_name, product_ndc: @medication.product_ndc}, method: :delete %>
 <p>Brand Name: <%= @medication.brand_name %></p>
 <p>Product NDC: <%= @medication.product_ndc %></p>
 <% if @medication.symptoms.empty? == false %>

--- a/app/views/medications/show.html.erb
+++ b/app/views/medications/show.html.erb
@@ -1,0 +1,13 @@
+<h3>Medication information</h3>
+<p>Brand Name: <%= @medication.brand_name %></p>
+<p>Product NDC: <%= @medication.product_ndc %></p>
+<% if @medication.symptoms.empty? == false %>
+  <div class="side-effects"</div>
+  <h4>Potential Side Effects:</h4>
+  <% @medication.symptoms.each do |symptom| %>
+    <ul>
+      <li><%= symptom.description %></li>
+    </ul>
+  <% end %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   post '/medications/create', to: 'medications#create'
   get '/medications/edit', to: 'medications#edit'
   delete '/medications/delete', to: 'medications#destroy'
+  get '/medications/:medication_id', to: 'medications#show'
 
   post '/logs', to: 'logs#create'
   get '/logs', to: 'logs#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   post '/medications/create', to: 'medications#create'
   get '/medications/edit', to: 'medications#edit'
   delete '/medications/delete', to: 'medications#destroy'
-  get '/medications/:medication_id', to: 'medications#show'
+  get '/medications/:id', to: 'medications#show'
 
   post '/logs', to: 'logs#create'
   get '/logs', to: 'logs#index'

--- a/spec/features/dashboard/medications/show_page_spec.rb
+++ b/spec/features/dashboard/medications/show_page_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'When I visit the dashboard as an authenticated user' do
 
   it 'I can click on the name of a medication and see that medication\'s show page' do
     VCR.use_cassette('adderall_search') do
+      click_on 'Add New Medication'
 
       expect(current_path).to eq('/medications/new')
       expect(page).to have_content("Enter medication brand name")

--- a/spec/features/dashboard/medications/show_page_spec.rb
+++ b/spec/features/dashboard/medications/show_page_spec.rb
@@ -38,7 +38,15 @@ RSpec.describe 'When I visit the dashboard as an authenticated user' do
       expect(page).to have_content("Brand Name: Adderall XR")
       expect(page).to have_content('Potential Side Effects:')
       within('.side-effects') do
+        expect(page).to have_content('Weight Loss')
+        expect(page).to have_content('Abdominal Pain (stomachache)')
+        expect(page).to have_content('Loss of Appetite')
+        expect(page).to have_content('Insomnia')
+        expect(page).to have_content('Nervousness')
         expect(page).to have_content('Headache')
+        expect(page).to have_content('Asthenia')
+        expect(page).to have_content('Tachycardia')
+        expect(page).to have_content('Urinary Tract Infection')
       end
     end
   end

--- a/spec/features/dashboard/medications/show_page_spec.rb
+++ b/spec/features/dashboard/medications/show_page_spec.rb
@@ -50,4 +50,39 @@ RSpec.describe 'When I visit the dashboard as an authenticated user' do
       end
     end
   end
+  it "I can delete a medication from my list from the medication show page" do
+    VCR.use_cassette('adderall_search') do
+      click_on 'Add New Medication'
+
+      expect(current_path).to eq('/medications/new')
+      expect(page).to have_content("Enter medication brand name")
+
+      fill_in :brand_name, with: 'Adderall'
+      click_on 'Find Medication'
+
+      expect(current_path).to eq('/medications/search')
+
+      expect(page).to have_content('Please select the correct medication brand name')
+
+      within('.medications', match: :first) do
+        expect(page).to have_button('Adderall XR')
+        click_on 'Adderall XR'
+      end
+
+      expect(current_path).to eq('/dashboard')
+      expect(page).to have_link('Adderall XR')
+
+      adderall_xr = Medication.find_by(brand_name: 'Adderall XR')
+
+      click_on 'Adderall XR'
+
+      expect(current_path).to eq("/medications/#{adderall_xr.id}")
+
+      click_on 'Delete Medication from my List'
+
+      visit dashboard_path
+
+      expect(page).to_not have_content('Adderall XR')
+    end
+  end
 end

--- a/spec/features/dashboard/medications/show_page_spec.rb
+++ b/spec/features/dashboard/medications/show_page_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'When I visit the dashboard as an authenticated user' do
+  before :each do
+    @user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    visit dashboard_path
+  end
+
+  it 'I can click on the name of a medication and see that medication\'s show page' do
+    VCR.use_cassette('adderall_search') do
+
+      expect(current_path).to eq('/medications/new')
+      expect(page).to have_content("Enter medication brand name")
+
+      fill_in :brand_name, with: 'Adderall'
+      click_on 'Find Medication'
+
+      expect(current_path).to eq('/medications/search')
+
+      expect(page).to have_content('Please select the correct medication brand name')
+
+      within('.medications', match: :first) do
+        expect(page).to have_button('Adderall XR')
+        click_on 'Adderall XR'
+      end
+
+      expect(current_path).to eq('/dashboard')
+      expect(page).to have_link('Adderall XR')
+
+      adderall_xr = Medication.find_by(brand_name: 'Adderall XR')
+
+      click_on 'Adderall XR'
+
+      expect(current_path).to eq("/medications/#{adderall_xr.id}")
+
+      expect(page).to have_content("Brand Name: Adderall XR")
+      expect(page).to have_content('Potential Side Effects:')
+      within('.side-effects') do
+        expect(page).to have_content('Headache')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Description
When a user clicks on the brand name of a medication, they are redirected to a medication show page where they see the following:
- Medication brand name
- Product NDC
- List of potential side effects associated with the medication
- A button to delete the medication from their list

This is associated with issue #55 but it doesn't close it because I would still like to do the following, if possible:

-  medication generic name
-  fields to enter prescribing doctor and dosage
-  have a short description of the medication
